### PR TITLE
New python driver

### DIFF
--- a/INSTALL_RASPBERRY_PI.md
+++ b/INSTALL_RASPBERRY_PI.md
@@ -50,10 +50,11 @@ $ echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
 ```
 
 ## Install pigpio driver
-Or, follow the [tutorial](https://github.com/pololu/dual-g2-high-power-motor-driver-rpi) to install pigpio driver
-```
+Follow the [tutorial](https://github.com/pololu/dual-g2-high-power-motor-driver-rpi) to install pigpio driver
+```shell
 sudo apt-get update
 sudo apt-get install pigpio python-pigpio
+# pip install pigpio
 ```
 start the service and check status
 ```

--- a/INSTALL_RASPBERRY_PI.md
+++ b/INSTALL_RASPBERRY_PI.md
@@ -50,7 +50,7 @@ $ echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
 ```
 
 ## Install pigpio driver
-Follow the [tutorial](https://github.com/pololu/dual-g2-high-power-motor-driver-rpi) to install pigpio driver
+Or, follow the [tutorial](https://github.com/pololu/dual-g2-high-power-motor-driver-rpi) to install pigpio driver
 ```
 sudo apt-get update
 sudo apt-get install pigpio python-pigpio
@@ -63,4 +63,9 @@ sudo systemctl status pigpoid
 auto start the service when boot
 ```
 sudo systemctl enable pigpoid
+```
+
+## Install [RPi.GPIO library](https://pypi.org/project/RPi.GPIO/)
+```shell
+pip install RPi.GPIO
 ```

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This is a python library for [Jazzy Elite ES](https://www.pridemobility.com/jazz
 - Raspberry pi (OS: buster)
 - Jazzy Elite ES mobile base
 - Pololu Dual G2 High-Power Motor Driver 18v22 for Rasberry Pi
+- [Cytron 30Amp Smart Drive](https://www.cytron.io/p-30amp-7v-35v-smartdrive-dc-motor-driver-2-channels)
 
 ## Installation
-Follow INSTALL_RASPBERRY_PI.md to install ROS melodic and pigpio
+Follow `INSTALL_RASPBERRY_PI.md` to install ROS melodic and pigpio
 
 ## Download this repo
 ```
@@ -33,7 +34,7 @@ sudo chmod +x ./scripts/jazzy_ros_interface.py
   export ROS_MASTER_URI=http:/192.168.1.19:11311
   export ROS_IP=[clinet machine ip]
   ```
-2. check /cmd_vel is available
+2. check `/cmd_vel` is available
 ```
   rostopic list
 ```

--- a/scripts/jazzy_ros_interface.py
+++ b/scripts/jazzy_ros_interface.py
@@ -3,6 +3,7 @@ import rospy
 from geometry_msgs.msg import Twist
 import time
 from dual_g2_hpmd_rpi import motors, MAX_SPEED
+# from mdds30_rpi import motors, MAX_SPEED
 import math
 
 class DriverFault(Exception):

--- a/scripts/mdds30_rpi.py
+++ b/scripts/mdds30_rpi.py
@@ -1,0 +1,79 @@
+"""
+Raspberry Pi dual motor driver using Cytron MDDS30
+
+Wiring:
+--------------------------------------------------
+MDDS30                  RPi
+IN1                     gpio 5
+IN2                     gpio 6
+AIN1                    gpio 12
+AIN2                    gpio 13
+--------------------------------------------------
+
+linzhank, 2022-03-25
+"""
+import RPi.GPIO as GPIO
+_pin_M1DIR = 5
+_pin_M2DIR = 6
+_pin_M1PWM = 12  # hardware pwm 0: 12 or 18
+_pin_M2PWM = 13  # hardware pwm 1: 13 or 19
+MAX_SPEED = 100.0
+
+
+class Motor(object):
+
+    def __init__(self, pwm_pin, dir_pin):
+        GPIO.setup(pwm_pin, GPIO.OUT)
+        self.pwm_signal = GPIO.PWM(pwm_pin, 10000)  # frequency=10000Hz
+        GPIO.setup(dir_pin, GPIO.OUT)
+        self.pwm_pin = pwm_pin
+        self.dir_pin = dir_pin
+
+    def setSpeed(self, speed):
+        if speed < 0:
+            speed = -speed
+            GPIO.output(self.dir_pin, GPIO.HIGH)
+        else:
+            GPIO.output(self.dir_pin, GPIO.LOW)
+        if speed > MAX_SPEED:
+            speed = MAX_SPEED
+        self.pwm_signal.start(speed)
+
+    def enable(self):
+        pass
+
+    def disable(self):
+        self.pwm_signal.start(0)
+
+    def getFault(self):
+        pass
+
+
+class Motors(object):
+
+    def __init__(self):
+        GPIO.setwarnings(False)
+        GPIO.setmode(GPIO.BCM)
+        self.motor1 = Motor(_pin_M1PWM, _pin_M1DIR)
+        self.motor2 = Motor(_pin_M2PWM, _pin_M2DIR)
+
+    def setSpeeds(self, m1_speed, m2_speed):
+        self.motor1.setSpeed(m1_speed)
+        self.motor2.setSpeed(m2_speed)
+
+    def enable(self):
+        self.motor1.enable()
+        self.motor2.enable()
+
+    def disable(self):
+        self.motor1.disable()
+        self.motor2.disable()
+
+    def getFaults(self):
+        pass
+
+    def forceStop(self):
+        self.disable()
+
+
+motors = Motors()


### PR DESCRIPTION
Please note:
1. Major change is created a python script for a Raspberrry Pi to drive [MDDS30](https://www.cytron.io/p-30amp-7v-35v-smartdrive-dc-motor-driver-2-channels) motor driver.
2. The python script should be able to realized through [pigio](https://abyz.me.uk/rpi/pigpio/) library too, but I found [RPi.GPIO](https://pypi.org/project/RPi.GPIO/) library is easier.
3. However, you'll need to install the new library via `pip install RPi.GPIO` if not preinstalled by default.
4. To use the new motor driver script, just comment line 4 in `scripts/jazzy_ros_interface.py` and coment out line 5.